### PR TITLE
Add `with_conflicts` option.

### DIFF
--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -20,7 +20,7 @@ on:
       # This should only be used when handling events where conflicts want to be seen.
       3way:
         required: false
-        type: bool
+        type: boolean
         default: false
   workflow_call:
     inputs:
@@ -38,7 +38,7 @@ on:
         type: string
       3way:
         required: false
-        type: bool
+        type: boolean
         default: false
 env:
   SRC_REPO: ${{ inputs.src_repo }}

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -118,7 +118,7 @@ jobs:
           # Apply patches
           if [ -d "../patches/${DIR}" ];
           then
-            git am $(if [ ${{ inputs.with_conflicts }} ]; then echo '--3way'; fi) --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${REF}/*.patch > /dev/null 2>&1
+            git am $(if [ ${{ inputs.with_conflicts }} ]; then echo '--3way'; fi) --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${REF}/*.patch
             git push origin ${REF} > /dev/null 2>&1
           fi
 

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -16,6 +16,10 @@ on:
       patch_repo:
         required: true
         type: string
+      patch_dir:
+        required: false
+        type: string
+        default: ${{ inputs.ref }}
       # 3way is used to apply the patches using a 3way merge strategy (git am --3way). This will apply the patches in the event of a conflict
       # This should only be used when handling events where conflicts want to be seen.
       with_conflicts:
@@ -36,6 +40,10 @@ on:
       patch_repo:
         required: true
         type: string
+      patch_dir:
+        required: false
+        type: string
+        default: ${{ inputs.ref }}
       with_conflicts:
         required: false
         type: boolean
@@ -108,7 +116,7 @@ jobs:
           git config --local user.email ${GIT_USER_EMAIL}
 
           # Apply patches
-          if [ -d "../patches/${REF}" ];
+          if [ -d "../patches/${patch_dir}" ];
           then
             git am $(if [ ${{ inputs.with_conflicts }} ]; then echo '--3way'; fi) --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${REF}/*.patch > /dev/null 2>&1
             git push origin ${REF} > /dev/null 2>&1

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -118,9 +118,22 @@ jobs:
           # Apply patches
           if [ -d "../patches/${DIR}" ];
           then
-            git am $(if [ ${{ inputs.with_conflicts }} ]; then echo '--3way'; fi) --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${DIR}/*.patch
-            git push origin ${REF} > /dev/null 2>&1
+            # If we're applying patches with conflicts then ignore the errors and add.
+            if [ ${{ inputs.with_conflicts }} ];
+            then 
+              # Ignore non-zero errors because `git am` will return > 0 if there are conflicts.
+              if [[ ! "git am --3way --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${DIR}/*.patch" ]];
+              then
+                # Add because these commits are unstaged
+                git add .
+                git commit -m "Add conflicting files..." --no-verify
+              fi
+            else
+              git am --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${DIR}/*.patch
+            fi
           fi
+
+          git push origin ${REF} > /dev/null 2>&1
 
           echo Patches applied.
 

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -129,6 +129,9 @@ jobs:
                 # Add because these commits are unstaged
                 git add .
                 git commit -m "Add conflicting files..." --no-verify
+              else
+                echo "3way patch applied without error"
+                git diff
               fi
             else
               echo "git am returned zero exit code; changes are compatible"

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -16,6 +16,12 @@ on:
       patch_repo:
         required: true
         type: string
+      # 3way is used to apply the patches using a 3way merge strategy (git am --3way). This will apply the patches in the event of a conflict
+      # This should only be used when handling events where conflicts want to be seen.
+      3way:
+        required: false
+        type: bool
+        default: false
   workflow_call:
     inputs:
       ref:
@@ -30,7 +36,10 @@ on:
       patch_repo:
         required: true
         type: string
-
+      3way:
+        required: false
+        type: bool
+        default: false
 env:
   SRC_REPO: ${{ inputs.src_repo }}
   DEST_REPO: ${{ inputs.dest_repo }}
@@ -101,9 +110,10 @@ jobs:
           # Apply patches
           if [ -d "../patches/${REF}" ];
           then
-            git am --committer-date-is-author-date -q ../patches/${REF}/*.patch > /dev/null 2>&1
+            git am $(if [ ${{ inputs.3way }} ]; then echo '--3way'; fi) --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${REF}/*.patch > /dev/null 2>&1
             git push origin ${REF} > /dev/null 2>&1
           fi
+
           echo Patches applied.
 
       - name: Handle patch failure

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -122,7 +122,7 @@ jobs:
             if [ ${{ inputs.with_conflicts }} ];
             then 
               # Ignore non-zero errors because `git am` will return > 0 if there are conflicts.
-              if [[ ! "git am --3way --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${DIR}/*.patch" ]];
+              if [[ ! "git am --3way --ignore-whitespace --ignore-space-change --committer-date-is-author-date ../patches/${DIR}/*.patch" ]];
               then
                 echo "git am returned non-zero exit code"
                 git diff
@@ -132,7 +132,7 @@ jobs:
               fi
             else
               echo "git am returned zero exit code; changes are compatible"
-              git am --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${DIR}/*.patch
+              git am --ignore-whitespace --ignore-space-change --committer-date-is-author-date ../patches/${DIR}/*.patch
             fi
           fi
 

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -122,7 +122,7 @@ jobs:
             if [ ${{ inputs.with_conflicts }} ];
             then 
               # Ignore non-zero errors because `git am` will return > 0 if there are conflicts.
-              if [[ ! "git am --3way --ignore-whitespace --ignore-space-change --committer-date-is-author-date ../patches/${DIR}/*.patch" ]];
+              if ! "git am --3way --ignore-whitespace --ignore-space-change --committer-date-is-author-date ../patches/${DIR}/*.patch";
               then
                 echo "git am returned non-zero exit code"
                 git diff
@@ -130,8 +130,7 @@ jobs:
                 git add .
                 git commit -m "Add conflicting files..." --no-verify
               else
-                echo "3way patch applied without error"
-                git diff
+                echo "3way patch applied iwthou"
               fi
             else
               echo "git am returned zero exit code; changes are compatible"

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -134,6 +134,8 @@ jobs:
               echo "git am returned zero exit code; changes are compatible"
               git am --ignore-whitespace --ignore-space-change --committer-date-is-author-date ../patches/${DIR}/*.patch
             fi
+          else
+            echo "Folder ${DIR} does not exist"
           fi
 
           git push origin ${REF} > /dev/null 2>&1

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -124,11 +124,14 @@ jobs:
               # Ignore non-zero errors because `git am` will return > 0 if there are conflicts.
               if [[ ! "git am --3way --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${DIR}/*.patch" ]];
               then
+                echo "git am returned non-zero exit code"
+                git diff
                 # Add because these commits are unstaged
                 git add .
                 git commit -m "Add conflicting files..." --no-verify
               fi
             else
+              echo "git am returned zero exit code; changes are compatible"
               git am --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${DIR}/*.patch
             fi
           fi

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -130,7 +130,7 @@ jobs:
                 git add .
                 git commit -m "Add conflicting files..." --no-verify
               else
-                echo "3way patch applied iwthou"
+                echo "3way patch applied without errors"
               fi
             else
               echo "git am returned zero exit code; changes are compatible"

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -19,7 +19,7 @@ on:
       patch_dir:
         required: false
         type: string
-      # 3way is used to apply the patches using a 3way merge strategy (git am --3way). This will apply the patches in the event of a conflict
+      # with_conflicts is used to apply the patches using a 3way merge strategy (git am --3way). This will apply the patches in the event of a conflict
       # This should only be used when handling events where conflicts want to be seen.
       with_conflicts:
         required: false
@@ -115,37 +115,27 @@ jobs:
           git config --local user.name ${GIT_USER}
           git config --local user.email ${GIT_USER_EMAIL}
 
-          # Apply patches
+          # Apply patches if the directory exists
           if [ -d "../patches/${DIR}" ];
           then
-            # If we're applying patches with conflicts then ignore the errors and add.
+            # If we're applying patches with conflicts then ignore the errors and `git add / git commit` the differences.
             if [ ${{ inputs.with_conflicts }} ];
             then 
-              # Ignore non-zero errors because `git am` will return > 0 if there are conflicts.
+              # If `git am --3way` is not successful then `git add / git commit`.
               if ! git am --3way --ignore-whitespace --ignore-space-change --committer-date-is-author-date ../patches/${DIR}/*.patch;
               then
-                echo "git am returned non-zero exit code"
-                git diff
                 # Add because these commits are unstaged
                 git add .
                 git commit -m "Add conflicting files..." --no-verify
-              else
-                echo "3way patch applied without errors"
               fi
             else
-              echo "git am returned zero exit code; changes are compatible"
+              # git am returned zero exit code; changes are compatible
               git am --ignore-whitespace --ignore-space-change --committer-date-is-author-date ../patches/${DIR}/*.patch
             fi
-          else
-            echo "Folder ${DIR} does not exist"
           fi
 
           git push origin ${REF} > /dev/null 2>&1
 
-          echo Patches applied.
-
       - name: Handle patch failure
         if: ${{ failure() && steps.patches.conclusion == 'failure' }}
         run: echo "::error title='Failed to apply patches when mirroring'::The sync process was not able to apply active patches to the mirror. See the documentation here for how to resolve this error."
-
-      

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -18,7 +18,7 @@ on:
         type: string
       # 3way is used to apply the patches using a 3way merge strategy (git am --3way). This will apply the patches in the event of a conflict
       # This should only be used when handling events where conflicts want to be seen.
-      3way:
+      with_conflicts:
         required: false
         type: boolean
         default: false
@@ -36,7 +36,7 @@ on:
       patch_repo:
         required: true
         type: string
-      3way:
+      with_conflicts:
         required: false
         type: boolean
         default: false
@@ -110,7 +110,7 @@ jobs:
           # Apply patches
           if [ -d "../patches/${REF}" ];
           then
-            git am $(if [ ${{ inputs.3way }} ]; then echo '--3way'; fi) --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${REF}/*.patch > /dev/null 2>&1
+            git am $(if [ ${{ inputs.with_conflicts }} ]; then echo '--3way'; fi) --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${REF}/*.patch > /dev/null 2>&1
             git push origin ${REF} > /dev/null 2>&1
           fi
 

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -19,7 +19,6 @@ on:
       patch_dir:
         required: false
         type: string
-        default: ${{ inputs.ref }}
       # 3way is used to apply the patches using a 3way merge strategy (git am --3way). This will apply the patches in the event of a conflict
       # This should only be used when handling events where conflicts want to be seen.
       with_conflicts:
@@ -43,7 +42,6 @@ on:
       patch_dir:
         required: false
         type: string
-        default: ${{ inputs.ref }}
       with_conflicts:
         required: false
         type: boolean
@@ -111,12 +109,14 @@ jobs:
         id: patches
         working-directory: dest 
         run: |
+          PATCH_DIR_INPUT=${{ inputs.patch_dir }}
+          DIR="${PATCH_DIR_INPUT:-$REF}"
           # Tell git who we are
           git config --local user.name ${GIT_USER}
           git config --local user.email ${GIT_USER_EMAIL}
 
           # Apply patches
-          if [ -d "../patches/${patch_dir}" ];
+          if [ -d "../patches/${DIR}" ];
           then
             git am $(if [ ${{ inputs.with_conflicts }} ]; then echo '--3way'; fi) --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${REF}/*.patch > /dev/null 2>&1
             git push origin ${REF} > /dev/null 2>&1

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -122,7 +122,7 @@ jobs:
             if [ ${{ inputs.with_conflicts }} ];
             then 
               # Ignore non-zero errors because `git am` will return > 0 if there are conflicts.
-              if ! "git am --3way --ignore-whitespace --ignore-space-change --committer-date-is-author-date ../patches/${DIR}/*.patch";
+              if ! git am --3way --ignore-whitespace --ignore-space-change --committer-date-is-author-date ../patches/${DIR}/*.patch;
               then
                 echo "git am returned non-zero exit code"
                 git diff

--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -118,7 +118,7 @@ jobs:
           # Apply patches
           if [ -d "../patches/${DIR}" ];
           then
-            git am $(if [ ${{ inputs.with_conflicts }} ]; then echo '--3way'; fi) --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${REF}/*.patch
+            git am $(if [ ${{ inputs.with_conflicts }} ]; then echo '--3way'; fi) --ignore-whitespace --ignore-space-change --committer-date-is-author-date -q ../patches/${DIR}/*.patch
             git push origin ${REF} > /dev/null 2>&1
           fi
 


### PR DESCRIPTION
This option will allow anyone to mirror their branch from the source repo to the destination repo with visible conflicts.

This will be very useful when trying to figure out where proposed changes conflict with patches in a low-risk environment.