### PR TITLE
use non-zero fetch depth in `mirror-branch-and-apply-patches.yml`

### DIFF
--- a/.github/workflows/mirror-branch-and-apply-patches.yml
+++ b/.github/workflows/mirror-branch-and-apply-patches.yml
@@ -90,7 +90,6 @@ jobs:
           path: src
           token: ${{ steps.generate_token.outputs.token }}
           progress: false
-          fetch-depth: 0
 
       - name: "Mirror src repo"
         id: mirror
@@ -122,7 +121,7 @@ jobs:
           ref: ${{ inputs.ref }}
           path: dest
           token: ${{ steps.generate_token.outputs.token }}
-          fetch-depth: 0
+          progerss: false
 
       - name: "Apply patches"
         id: patches


### PR DESCRIPTION
It's probably not wise to fetch all of the possible refs from the destination and source, especially when the `checkout` action checks out the correct ref for mirroring.